### PR TITLE
Set sphinx version to 2.2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-sphinx==2.4.5
+sphinx==2.2.2
 sphinx-intl==2.0.1
 docutils==0.14
 sphinxcontrib-svg2pdfconverter==1.0.1


### PR DESCRIPTION
Pdf build fails due to the bug https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=955094
The solution is to set sphinx version to 2.2.2.