### PR TITLE
Add dvisvgm package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN mkdir -p /usr/share/man/man1 && \
         git=1:* \
         build-essential=12.* \
         libc6-dev=2* \
+        dvisvgm=2.11.1-1 \
         cmake=3.* && \
     curl -L https://tarantool.io/release/2.6/installer.sh | bash && \
     apt-get install -y tarantool=2.6.* tarantool-dev=2.6.* \

--- a/Dockerfile-slim
+++ b/Dockerfile-slim
@@ -13,6 +13,7 @@ RUN mkdir -p /usr/share/man/man1 && \
         librsvg2-bin=2.* \
         plantuml=1:1.* \
         make=4.* \
+        dvisvgm=2.11.1-1 \
         cmake=3.* && \
     rm -rf /var/lib/apt/lists/* \
     && pip install -r /tmp/requirements.txt --no-cache-dir \


### PR DESCRIPTION
Sphinx requires dvisvgm for rendering formulas with the
:math: role into SVG images. See the docs for details:
https://www.sphinx-doc.org/en/master/usage/extensions/math.html#module-sphinx.ext.imgmath

Resolves tarantool/doc#2959