### PR TITLE
Add the sphinx-toolbox extension

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
-.git
 .idea
+.git
+.github
 .gitignore
 .dockerignore
 README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.8-slim
 
-LABEL maintainer="Artem Morozov <artem.morozov@corp.mail.ru>"
+LABEL maintainer=""
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/Dockerfile-slim
+++ b/Dockerfile-slim
@@ -1,6 +1,6 @@
 FROM python:3.8-slim
 
-LABEL maintainer="Artem Morozov <artem.morozov@corp.mail.ru>"
+LABEL maintainer=""
 
 COPY requirements.txt /tmp/requirements.txt
 

--- a/README.md
+++ b/README.md
@@ -39,17 +39,29 @@ docker run --rm -it -v $(pwd):/doc tarantool/doc-builder sh -c "make <doc>"
 
 ## What's on board:
 
-- sphinx 1.8.5
-- texlive 
-- graphviz
-- sphinx-intl
-- docutils
-- sphinxcontrib-svg2pdfconverter
+- Sphinx 4.3.1
+- Some image processing tools:
+
+  - graphviz
+  - dvisvgm
+  - imagemagick
+  - sphinxcontrib-svg2pdfconverter
+
+- Sphinx themes and plugins:
+
+  - sphinx-rtd-theme
+  - pydata-sphinx-theme
+  - ablog
+  - pygments-graphql
+  - sphinx-intl and polib for localization
+  - recommonmark for Markdown support
+
+Tools for building and deploying docs:
+
 - sphinx-autobuild
+- curl
+- cmake
 - awscli
-- pandoc
-- panflute
-- dvisvgm
 
 ## Version history
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ Tools for building and deploying docs:
 
 ### Unreleased
 
+### 4.3
+
+* Add the [sphinx-toolbox](https://sphinx-toolbox.readthedocs.io) extension.
+
 ### 4.2
 
 * Add recommonmark and sphinx-rtd-theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pygments-graphql==1.0.0
 sphinx-panels==0.6.0
 recommonmark==0.7.1
 sphinx-rtd-theme==1.0.0
+sphinx-toolbox==3.4.0


### PR DESCRIPTION
The Doc team wants to try collapsible blocks with the `sphinx-toolbox.collapse` extension. https://sphinx-toolbox.readthedocs.io/en/stable/extensions/collapse.html