### PR TITLE
dockerfile: update base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM python:3.8-slim-bookworm
 
 LABEL maintainer="Artem Morozov <artem.morozov@corp.mail.ru>"
 

--- a/Dockerfile-slim
+++ b/Dockerfile-slim
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM python:3.8-slim-bookworm
 
 LABEL maintainer="Artem Morozov <artem.morozov@corp.mail.ru>"
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ docker run --rm -it -v $(pwd):/doc tarantool/doc-builder sh -c "make <doc>"
 
 ### Unreleased
 
+### 4.4
+
+* base Docker image updated to `3.8-slim-bookworm`
+
 ### 4.3
 
 * myst-parser added


### PR DESCRIPTION
To resolve tarantool/doc#3548 and tarantool/tdg-doc#476, we need `pandoc`. On the Debian Bullseye, current base Docker image, pandoc installs with `pandoc-types` package version 1.20. With this version, pandoc fails with the error "Invalid API version: [1, 20]". On the Debian Bookworm, `pandoc` installs with `pandoc-types` package version 1.22 and works correctly.